### PR TITLE
Reduce devdata calls

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -57,7 +57,7 @@ const App = () => {
           // update dev context with current user
           devCtx.updateDev(developerData)
           setupCtx.updateInitialized();
-          setupCtx.updateDevUpdated()
+          setupCtx.updateDevUpdated(false)
         })
       }
     };

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -12,13 +12,14 @@ import Settings from "./pages/Settings/Settings";
 import DevDataContext from "./contexts/DevDataContext";
 import SetupContext from "./contexts/SetupContext";
 import CreateAccountComp from "./components/CreateAccountcomp";
+import { set } from "mongoose";
 
 // devData - This is in the format of how we are reading the database.
 // state is set after call to db for active developer info and repos to display
 const App = () => {
   const setupCtx = useContext(SetupContext);
   console.log('APP init setupCtx', setupCtx)
-  console.log('APP setup isLoaded', JSON.stringify(setupCtx.state.isLoaded))
+  console.log('APP setup devUpdated', JSON.stringify(setupCtx.state.devUpdated))
 
   const devCtx = useContext(DevDataContext);
   console.log('APP devCtx', devCtx)
@@ -36,29 +37,32 @@ const App = () => {
       if (localStorage.getItem('jtsy-login') === 'true') {
         setupCtx.updateLoggedIn();
       }
-      API.getActiveDevData().then((activeDevData) => {
-        console.log('APP activeDevData', activeDevData.data);
+      console.log('APP devUpdated', setupCtx.state.devUpdated)
+      if (setupCtx.state.devUpdated) {
+        API.getActiveDevData().then((activeDevData) => {
+          console.log('APP activeDevData', activeDevData.data);
 
-        const developerData = {
-          developerLoginName: activeDevData.data.developerLoginName,
-          developerGithubID: activeDevData.data.developerGithubID,
-          repositories: activeDevData.data.repositories,
-          displayRepos: activeDevData.data.displayRepos,
-          fname: activeDevData.data.fname,
-          lname: activeDevData.data.lname,
-          email: activeDevData.data.email,
-          linkedInLink: activeDevData.data.linkedInLink,
-          resumeLink: activeDevData.data.resumeLink,
-          active: true
-        }
-        console.log('APP after DB call', developerData)
-        // update dev context with current user
-        devCtx.updateDev(developerData)
-        setupCtx.updateInitialized();
-
-      })
+          const developerData = {
+            developerLoginName: activeDevData.data.developerLoginName,
+            developerGithubID: activeDevData.data.developerGithubID,
+            repositories: activeDevData.data.repositories,
+            displayRepos: activeDevData.data.displayRepos,
+            fname: activeDevData.data.fname,
+            lname: activeDevData.data.lname,
+            email: activeDevData.data.email,
+            linkedInLink: activeDevData.data.linkedInLink,
+            resumeLink: activeDevData.data.resumeLink,
+            active: true
+          }
+          console.log('APP after DB call', developerData)
+          // update dev context with current user
+          devCtx.updateDev(developerData)
+          setupCtx.updateInitialized();
+          setupCtx.updateDevUpdated()
+        })
+      }
     };
-  }, [])
+  }, [setupCtx.state.devUpdated])
 
   console.log('APP initialized', initialized)
   // if (localStorage.getItem("jtsy-signin") === "true") {

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -46,7 +46,6 @@ const App = () => {
             developerLoginName: activeDevData.data.developerLoginName,
             developerGithubID: activeDevData.data.developerGithubID,
             repositories: activeDevData.data.repositories,
-            displayRepos: activeDevData.data.displayRepos,
             fname: activeDevData.data.fname,
             lname: activeDevData.data.lname,
             email: activeDevData.data.email,

--- a/client/src/components/DevTable/index.js
+++ b/client/src/components/DevTable/index.js
@@ -1,8 +1,9 @@
 // import axios from "axios";
 import _ from "lodash";
 import React, { useState, useEffect, useContext, Fragment } from "react";
-import { Table, Form, Button, Modal, Container, Segment, Checkbox } from "semantic-ui-react";
+import { Table, Form, Button, Modal, Container, Segment, Checkbox, Responsive } from "semantic-ui-react";
 import DevDataContext from '../../contexts/DevDataContext';
+import SetupContext from '../../contexts/SetupContext';
 import API from "../../utils/API";
 import RepoSearchBox from "../RepoSearchBox";
 import './style.css'
@@ -12,7 +13,13 @@ var filteredList = []
 
 const DevTable = () => {
   const devCtx = useContext(DevDataContext)
-  console.log('DEVTABLE devCtx', devCtx)
+  const repos = devCtx.state.repositories;
+  console.log('DEVTABLE devCtx', devCtx, 'repos', repos)
+
+
+  const setupCtx = useContext(SetupContext);
+  console.log('DEVTABLE setupCtx', setupCtx)
+
   const [state, setState] = useState({
     id: null,
     column: null,
@@ -31,23 +38,44 @@ const DevTable = () => {
   })
 
   useEffect(() => {
-    console.log('DevTable 1.  in useEffect')
-    API.getActiveDevData()
-      .then(res => {
-        // console.log('DevTable 2. ')
-        setState({
-          ...state,
-          data: res.data.repositories,
-          filteredRepos: res.data.repositories,
-        });
-        tableData = res.data.repositories
-        console.log('DEVTABLE useEffect tableData', tableData)
-        const developerData = {
-          repositories: tableData,
-        }
-        devCtx.updateDev(developerData)
-      });
-  }, []);
+    console.log('DEVTABLE else devCtx', devCtx)
+    const repos = devCtx.state.repositories;
+    setState({
+      ...state,
+      data: repos,
+      filteredRepos: repos
+    })
+  }, [repos])
+
+
+  // useEffect(() => {
+  //   console.log('DevTable 1.  in useEffect updateDev', setupCtx.state.updateDev)
+  //   if (false) {
+  //     API.getActiveDevData()
+  //       .then(res => {
+  //         // console.log('DevTable 2. ')
+  //         setState({
+  //           ...state,
+  //           data: res.data.repositories,
+  //           filteredRepos: res.data.repositories,
+  //         });
+  //         tableData = res.data.repositories
+  //         console.log('DEVTABLE useEffect tableData', tableData)
+  //         const developerData = {
+  //           repositories: tableData,
+  //         }
+  //         devCtx.updateDev(developerData);
+  //       });
+  //   } else {
+  //     console.log('DEVTABLE else devCtx', devCtx)
+  //     const repos = devCtx.state.repositories;
+  //     setState({
+  //       ...state,
+  //       data: repos,
+  //       filteredRepos: repos
+  //     })
+  //   }
+  // }, []);
 
   const handleSort = (clickedColumn) => () => {
     const { column, filteredRepos, direction } = state;

--- a/client/src/components/DevTable/index.js
+++ b/client/src/components/DevTable/index.js
@@ -37,15 +37,17 @@ const DevTable = () => {
     keywords: ""
   })
 
+  tableData = devCtx.state.repositories;
+
   useEffect(() => {
-    console.log('DEVTABLE else devCtx', devCtx)
-    const repos = devCtx.state.repositories;
+    console.log('DEVTABLE devCtx', devCtx)
+
     setState({
       ...state,
-      data: repos,
-      filteredRepos: repos
+      data: tableData,
+      filteredRepos: tableData
     })
-  }, [repos])
+  }, [tableData])
 
 
   // useEffect(() => {

--- a/client/src/components/Settings/index.js
+++ b/client/src/components/Settings/index.js
@@ -49,7 +49,7 @@ const SettingsComp = () => {
         }
         console.log('in Settings: call updateDeveloper', revDevData.developerGithubID)
         API.revDeveloper(revDevData)
-        setupCtx.updateDevUpdated();
+        setupCtx.updateDevUpdated(true);
         setState({
             ...state,
             redirect: true,

--- a/client/src/components/Settings/index.js
+++ b/client/src/components/Settings/index.js
@@ -2,12 +2,16 @@ import React, { useState, useContext, useEffect } from "react";
 import { Redirect } from 'react-router'
 import API from "../../utils/API";
 import DevDataContext from "../../contexts/DevDataContext";
+import SetupContext from "../../contexts/SetupContext";
 
 console.log('in Settings')
 
 const SettingsComp = () => {
     const devCtx = useContext(DevDataContext);
     console.log("SETTINGS devCtx", devCtx.state, typeof devCtx.state)
+
+    const setupCtx = useContext(SetupContext);
+    console.log("SETTINGS setupCtx", setupCtx)
 
     // let testName = devCtx.state.fname
     // console.log('testName', testName, typeof testName)
@@ -45,6 +49,7 @@ const SettingsComp = () => {
         }
         console.log('in Settings: call updateDeveloper', revDevData.developerGithubID)
         API.revDeveloper(revDevData)
+        setupCtx.updateDevUpdated();
         setState({
             ...state,
             redirect: true,

--- a/client/src/contexts/SetupContext.js
+++ b/client/src/contexts/SetupContext.js
@@ -7,7 +7,8 @@ export const SetupProvider = (props) => {
     const [state, setState] = useState({
         isLoaded: false,
         initialized: false,
-        loggedIn: false
+        loggedIn: false,
+        devUpdated: true
     });
 
     return (
@@ -23,6 +24,10 @@ export const SetupProvider = (props) => {
                 updateLoggedIn: () => {
                     console.log('setupCtx updateLoggedIn')
                     !state.loggedIn ? setState({ ...state, loggedIn: true }) : setState({ ...state, loggedIn: false });
+                },
+                updateDevUpdated: () => {
+                    console.log('setupCtx updateDevUpdated')
+                    !state.devUpdated ? setState({ ...state, devUpdated: true }) : setState({ ...state, devUpdated: false });
                 },
                 resetSetup: () => {
                     console.log('setupCtx resetSetup')

--- a/client/src/contexts/SetupContext.js
+++ b/client/src/contexts/SetupContext.js
@@ -25,9 +25,12 @@ export const SetupProvider = (props) => {
                     console.log('setupCtx updateLoggedIn')
                     !state.loggedIn ? setState({ ...state, loggedIn: true }) : setState({ ...state, loggedIn: false });
                 },
-                updateDevUpdated: () => {
-                    console.log('setupCtx updateDevUpdated')
-                    !state.devUpdated ? setState({ ...state, devUpdated: true }) : setState({ ...state, devUpdated: false });
+                updateDevUpdated: (value) => {
+                    console.log('setupCtx updateDevUpdated', value)
+                    setState({
+                        ...state,
+                        devUpdated: value
+                    })
                 },
                 resetSetup: () => {
                     console.log('setupCtx resetSetup')


### PR DESCRIPTION
Goal:  Reduce calls to getActiveDevData (was called on every re-render)
Solution:
- Added property devUpdated to SetupContext (set to true)
- Added if condition in App to only call getActiveDevData if devUpdated is true.
- In App, set devUpdated to false after call
- In Settings, added setting of devUpdated to true onSubmit